### PR TITLE
n3: drop getAddressAbstracts()

### DIFF
--- a/src/api/neo/rest.ts
+++ b/src/api/neo/rest.ts
@@ -7,7 +7,6 @@ import type {
   BlocksResponse,
   ContractResponse,
   ContractsResponse,
-  GetAddressAbstractsResponse,
   GetAllNodesResponse,
   HeightResponse,
   InvocationStatsResponse,
@@ -120,15 +119,6 @@ export class NeoRESTApi {
   ): Promise<Object> {
     const method = 'contract_stats'
     return await this.get(network, method, contractHash)
-  }
-
-  async getAddressAbstracts(
-    address: string,
-    page = 1,
-    network = 'mainnet'
-  ): Promise<GetAddressAbstractsResponse> {
-    const method = 'get_address_abstracts'
-    return await this.get(network, method, address, page)
   }
 
   async getAllNodes(network = 'mainnet'): Promise<GetAllNodesResponse> {

--- a/src/interfaces/api/neo/responses.ts
+++ b/src/interfaces/api/neo/responses.ts
@@ -1,5 +1,4 @@
 import {
-  AddressAbstractEntry,
   Asset,
   ContractInvocationStats,
   Balance,
@@ -85,14 +84,6 @@ export interface ContractResponse {
 export interface ContractsResponse {
   items: Contract[]
   totalCount: number
-}
-
-export interface GetAddressAbstractsResponse {
-  total_pages: number
-  total_entries: number
-  page_size: number
-  page_number: number
-  entries: AddressAbstractEntry[]
 }
 
 export type GetAllNodesResponse = NodeMetaData[]


### PR DESCRIPTION
After looking at the code for Dora, neon-wallet desktop and mobile none of those projects use this endpoint. On Dora v2 I deleted the `/get_address_abstracts/` endpoint as it already wasn't implemented and also won't be now. This endpoint seems to be a port of the legacy/NeoSCAN API and a good time to clean up.