### PR TITLE
n3: deprecate addressTXFull

### DIFF
--- a/src/api/neo/rest.ts
+++ b/src/api/neo/rest.ts
@@ -48,7 +48,7 @@ export class NeoRESTApi {
   }
 
   /**
-   * @deprecated use addressTransactions instead.
+   * @deprecated use addressTransactions instead
    */
   async addressTXFull(
     address: string,

--- a/src/api/neo/rest.ts
+++ b/src/api/neo/rest.ts
@@ -47,6 +47,9 @@ export class NeoRESTApi {
     return await this.get(network, method, address, page)
   }
 
+  /**
+   * @deprecated use addressTransactions instead.
+   */
   async addressTXFull(
     address: string,
     page = 1,

--- a/src/tests/api/neo/neo.test.ts
+++ b/src/tests/api/neo/neo.test.ts
@@ -174,7 +174,7 @@ describe('neo sdk', () => {
   })
 
   it('should get the full transactions history for an address', async () => {
-    const res = await NeoRest.addressTXFull(
+    const res = await NeoRest.addressTransactions(
       'Nb9QYTVx8F6j5kKi1k1ERaUTFfSX5JRq2D',
       1,
         'testnet'

--- a/src/tests/api/neo/neo.test.ts
+++ b/src/tests/api/neo/neo.test.ts
@@ -137,18 +137,6 @@ describe('neo sdk', () => {
     assert.strictEqual(res.items.length, 15)
   })
 
-  // TODO: broken on API v1 side, v2 not yet implemented. Skip for now
-  // it('should get the enhanced transactions for an address', async () => {
-  //   const res = await NeoRest.addressTransactions(
-  //     'Nb9QYTVx8F6j5kKi1k1ERaUTFfSX5JRq2D',
-  //     1
-  //   )
-  //   assert.isNotNull(res)
-  //   assert.isObject(res)
-  //   assert.isArray(res.items)
-  //   assert.isAtLeast(res.items.length, 14)
-  // })
-
   it('should get transfer history', async () => {
     const res = await NeoRest.transferHistory(
       'Nb9QYTVx8F6j5kKi1k1ERaUTFfSX5JRq2D',


### PR DESCRIPTION
Endpoints on v2 will change from `/address_txfull/` to `/address_transactions/`. 

CI for this PR will fail until the base branch is pointed at `/v2/` (as `/v1/` does not have the new endpoint) + Dora needs to implement `/address_transactions/`. 

### **Wait with merging**