### PR TITLE
n3: expose InvocationType

### DIFF
--- a/src/interfaces/api/neo/interface.ts
+++ b/src/interfaces/api/neo/interface.ts
@@ -36,8 +36,15 @@ export interface Event {
   parameters: Parameter[]
 }
 
+export enum InvocationType {
+  NEP17_TRANSFER = 'nep17_transfer',
+  NEP11_TRANSFER = 'nep11_transfer',
+  CONTRACT = 'contract_invocation',
+  VOTE = 'vote'
+}
+
 export interface InvocationDetails {
-  type: string
+  type: InvocationType
   metadata:
     | InvocationDetailNEP17Transfer
     | InvocationDetailNEP11Transfer

--- a/src/interfaces/api/neo/interface.ts
+++ b/src/interfaces/api/neo/interface.ts
@@ -39,7 +39,7 @@ export interface Event {
 export enum InvocationType {
   NEP17_TRANSFER = 'nep17_transfer',
   NEP11_TRANSFER = 'nep11_transfer',
-  CONTRACT = 'contract_invocation',
+  CONTRACT_INVOCATION = 'contract_invocation',
   VOTE = 'vote'
 }
 


### PR DESCRIPTION
While investigating the requirements for implementing `/address_transactions/` (a.k.a `/address_txfull/`) I ran into the issue that I had to figure out what the `InvocationDetails.type` field was restricted to. I found a bunch of constants in the [neon-wallet desktop source](https://github.com/CityOfZion/neon-wallet/blob/6bfe1c133e8e730c9f20892aca28dc6d64a536ba/app/core/constants.js#L203-L206) that I believe represent this field.

This PR restricts the field to those constants and exposes them such that consumers of the SDK can use them for matching.