### PR TITLE
n3: fix notification state types

### DIFF
--- a/src/interfaces/api/common/index.ts
+++ b/src/interfaces/api/common/index.ts
@@ -59,7 +59,7 @@ export interface TransferAbstract {
 
 export interface TypedResponse {
   type: string
-  value: any
+  value?: string
 }
 
 export interface Witness {

--- a/src/interfaces/api/neo/interface.ts
+++ b/src/interfaces/api/neo/interface.ts
@@ -123,7 +123,7 @@ export interface NEF {
 export interface Notification {
   contract: string
   event_name: string
-  state: TypedResponse
+  state: TypedResponse[]
 }
 
 export interface Parameter {


### PR DESCRIPTION
Fixes 2 things:
1. notification `state` can be an array
2. the `value` field of the translated the stack item (represented as `TypedResponse`here) is always a string if present. The only time it's not present is when translating a `NullStackItem` which is represented as `{"type": "Any"}` (thanks C# team for the consistent interface)