### PR TITLE
ci : update CircleCi docker node image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 defaults: &defaults
   working_directory: ~/dora-sdk-ts
   docker:
-    - image: cimg/node:14.21.3
+    - image: cimg/node:18.17.0
 
 jobs:
   test:


### PR DESCRIPTION
Replace with Node18 as its now LTS, Node14 is deprecated