### PR TITLE
Add Neo X REST client with getAddress support

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,2 +1,3 @@
 export * from './neoN3'
 export * from './neoLegacy'
+export * from './neox'

--- a/src/api/neox/index.ts
+++ b/src/api/neox/index.ts
@@ -1,0 +1,1 @@
+export * from './rest'

--- a/src/api/neox/rest.ts
+++ b/src/api/neox/rest.ts
@@ -1,0 +1,38 @@
+import type { RestConfig } from '../../interfaces'
+import { DORA_URL } from '../../constants'
+import type { AxiosInstance, AxiosRequestConfig } from 'axios'
+import axios from 'axios'
+import type { Address } from '../../interfaces/api/neox'
+
+const DefaultNeoXRestConfig: RestConfig = {
+  doraUrl: DORA_URL,
+  endpoint: '/api/neox'
+}
+
+export class NeoXRESTApi {
+  protected axios: AxiosInstance
+  public constructor(
+    restConfig: RestConfig = DefaultNeoXRestConfig,
+    axiosConfig?: AxiosRequestConfig
+  ) {
+    if (typeof axiosConfig === 'undefined') {
+      axiosConfig = { baseURL: restConfig.doraUrl + restConfig.endpoint }
+    } else {
+      axiosConfig['baseURL'] = restConfig.doraUrl + restConfig.endpoint
+    }
+
+    this.axios = axios.create(axiosConfig)
+  }
+
+  async getAddress(addressHash: string, network = 'mainnet'): Promise<Address> {
+    return await this.get(network, 'addresses', addressHash)
+  }
+
+  private async get(...args: unknown[]) {
+    const endpoint = args.join('/')
+    const { data } = await this.axios.get(`/${endpoint}`)
+    return data
+  }
+}
+
+export const NeoXREST = new NeoXRESTApi()

--- a/src/interfaces/api/index.ts
+++ b/src/interfaces/api/index.ts
@@ -1,2 +1,3 @@
 export * as NeoLegacy from './neo_legacy'
 export * as NeoN3 from './neo'
+export * as NeoX from './neox'

--- a/src/interfaces/api/neox/index.ts
+++ b/src/interfaces/api/neox/index.ts
@@ -1,31 +1,31 @@
 export interface Address {
+  hash: string
   creator_address_hash?: string
   creation_tx_hash?: string
   token?: Token
-  coin_balance: string
+  coin_balance?: string
   exchange_rate?: string
   implementation_address?: string
-  block_number_balance_updated_at: number
-  hash: string
+  block_number_balance_updated_at?: number
   implementation_name?: string
   name?: string
-  is_contract: boolean
-  private_tags: AddressTag[]
-  watchlist_names: WatchlistName[]
-  public_tags: AddressTag[]
-  is_verified: boolean
-  has_beacon_chain_withdrawals: boolean
-  has_custom_methods_read: boolean
-  has_custom_methods_write: boolean
-  has_decompiled_code: boolean
-  has_logs: boolean
-  has_methods_read: boolean
-  has_methods_write: boolean
-  has_methods_read_proxy: boolean
-  has_methods_write_proxy: boolean
-  has_token_transfers: boolean
-  has_tokens: boolean
-  has_validated_blocks: boolean
+  is_contract?: boolean
+  private_tags?: AddressTag[]
+  watchlist_names?: WatchlistName[]
+  public_tags?: AddressTag[]
+  is_verified?: boolean
+  has_beacon_chain_withdrawals?: boolean
+  has_custom_methods_read?: boolean
+  has_custom_methods_write?: boolean
+  has_decompiled_code?: boolean
+  has_logs?: boolean
+  has_methods_read?: boolean
+  has_methods_write?: boolean
+  has_methods_read_proxy?: boolean
+  has_methods_write_proxy?: boolean
+  has_token_transfers?: boolean
+  has_tokens?: boolean
+  has_validated_blocks?: boolean
 }
 
 export interface AddressTag {
@@ -36,15 +36,15 @@ export interface AddressTag {
 
 export interface Token {
   address: string
-  circulating_market_cap: string
-  icon_url?: string
+  symbol: string
   name: string
   decimals: string
-  symbol: string
   type: string
   holders: string
   exchange_rate: string
   total_supply: string
+  circulating_market_cap?: string
+  icon_url?: string
 }
 
 export interface WatchlistName {

--- a/src/interfaces/api/neox/index.ts
+++ b/src/interfaces/api/neox/index.ts
@@ -1,14 +1,14 @@
 export interface Address {
-  creator_address_hash: string | null
-  creation_tx_hash: string | null
-  token: Token | null
+  creator_address_hash?: string
+  creation_tx_hash?: string
+  token?: Token
   coin_balance: string
-  exchange_rate: string | null
-  implementation_address: string | null
+  exchange_rate?: string
+  implementation_address?: string
   block_number_balance_updated_at: number
   hash: string
-  implementation_name: string | null
-  name: string | null
+  implementation_name?: string
+  name?: string
   is_contract: boolean
   private_tags: AddressTag[]
   watchlist_names: WatchlistName[]
@@ -37,7 +37,7 @@ export interface AddressTag {
 export interface Token {
   address: string
   circulating_market_cap: string
-  icon_url: string | null
+  icon_url?: string
   name: string
   decimals: string
   symbol: string

--- a/src/interfaces/api/neox/index.ts
+++ b/src/interfaces/api/neox/index.ts
@@ -1,0 +1,53 @@
+export interface Address {
+  creator_address_hash: string | null
+  creation_tx_hash: string | null
+  token: Token | null
+  coin_balance: string
+  exchange_rate: string | null
+  implementation_address: string | null
+  block_number_balance_updated_at: number
+  hash: string
+  implementation_name: string | null
+  name: string | null
+  is_contract: boolean
+  private_tags: AddressTag[]
+  watchlist_names: WatchlistName[]
+  public_tags: AddressTag[]
+  is_verified: boolean
+  has_beacon_chain_withdrawals: boolean
+  has_custom_methods_read: boolean
+  has_custom_methods_write: boolean
+  has_decompiled_code: boolean
+  has_logs: boolean
+  has_methods_read: boolean
+  has_methods_write: boolean
+  has_methods_read_proxy: boolean
+  has_methods_write_proxy: boolean
+  has_token_transfers: boolean
+  has_tokens: boolean
+  has_validated_blocks: boolean
+}
+
+export interface AddressTag {
+  address_hash: string
+  display_name: string
+  label: string
+}
+
+export interface Token {
+  address: string
+  circulating_market_cap: string
+  icon_url: string | null
+  name: string
+  decimals: string
+  symbol: string
+  type: string
+  holders: string
+  exchange_rate: string
+  total_supply: string
+}
+
+export interface WatchlistName {
+  display_name: string
+  label: string
+}

--- a/src/tests/api/NeoN3/neo.test.ts
+++ b/src/tests/api/NeoN3/neo.test.ts
@@ -176,12 +176,18 @@ describe('neo sdk', () => {
   })
 
   it('should get the token provenance', async () => {
-    const res = await NeoN3REST.tokenProvenance('0x904deb56fdd9a87b48d89e0cc0ac3415f9207840', '31')
-    assert.equal(JSON.stringify(res[0]),   JSON.stringify({
-      blockheight: 3344359,
-      timestamp: 1682461762,
-      txid: '0xece84f5ddd3787915a8c113f5f8748be5fc2dff560b202304264de42fb2b83ca',
-      owner: 'NaZwraSdJv9BYwYzZryiZcydaPDof56beK'
-    }))
+    const res = await NeoN3REST.tokenProvenance(
+      '0x904deb56fdd9a87b48d89e0cc0ac3415f9207840',
+      '31'
+    )
+    assert.equal(
+      JSON.stringify(res[0]),
+      JSON.stringify({
+        blockheight: 3347807,
+        timestamp: 1682517332,
+        txid: '0xdc78f791dddaca469772f49a21431c85b53eb9bea5d3ac02a12aaa8e40c1ba7d',
+        owner: 'NY8cnjo4F3sNw5cxMCwwHBsi8FqHvnJBXC'
+      })
+    )
   })
 })

--- a/src/tests/api/NeoX/neox.test.ts
+++ b/src/tests/api/NeoX/neox.test.ts
@@ -1,0 +1,20 @@
+import { assert } from 'chai'
+import { NeoXREST } from '../../../api/neox'
+
+describe('neox sdk', () => {
+  it('should get address information', async () => {
+    const addr = '0xd6BC5f7D2441A677218eBee5bCeE91d7f7a748E2'
+    const res = await NeoXREST.getAddress(addr)
+
+    assert.isNotNull(res)
+    assert.strictEqual(res.hash, addr)
+    assert.isBoolean(res.is_contract)
+    assert.isString(res.coin_balance)
+    assert.isBoolean(res.is_verified)
+
+    assert.property(res, 'name')
+    assert.property(res, 'private_tags')
+    assert.property(res, 'public_tags')
+    assert.property(res, 'watchlist_names')
+  })
+})


### PR DESCRIPTION
@lllwvlvwlll mentioned that having the endpoints for the new Neo X API would be good.

This is provided by this node: https://github.com/CityOfZion/neox-blockscout

API docs are here if you're interested: https://eth.blockscout.com/api-docs

Keeping PRs small for now, this adds:

- Client class
- Support for get address