### PR TITLE
fix tests and update base URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cityofzion/dora-ts",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cityofzion/dora-ts",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "1.8.2"

--- a/src/api/neoLegacy/rest.ts
+++ b/src/api/neoLegacy/rest.ts
@@ -10,7 +10,6 @@ import type {
   ContractTransfersResponse,
   GetAddressAbstractsResponse,
   GetAllNodesResponse,
-  GetClaimableResponse,
   GetUnclaimedResponse,
   HeightResponse,
   InvocationStatsResponse,
@@ -32,7 +31,7 @@ import { GetFullTransactionsByAddressResponse } from '../../interfaces/api/commo
 
 const DefaultLegacyRestConfig: RestConfig = {
   doraUrl: DORA_URL,
-  endpoint: '/api/v1/neo2'
+  endpoint: '/api/v2/neo2'
 }
 
 export class NeoLegacyRESTApi {
@@ -51,7 +50,7 @@ export class NeoLegacyRESTApi {
     }
 
     this.axios = axios.create(axiosConfig)
-    this.axiosDoraV2 = axios.create({ baseURL: `${DORA_URL}/api/v2` })
+    this.axiosDoraV2 = axios.create({ baseURL: `${DORA_URL}/api/v2/` })
   }
 
   async addressStats(
@@ -136,14 +135,6 @@ export class NeoLegacyRESTApi {
   async getAllNodes(network = 'mainnet'): Promise<GetAllNodesResponse> {
     const method = 'get_all_nodes'
     return await this.get(network, method)
-  }
-
-  async getClaimable(
-    address: string,
-    network = 'mainnet'
-  ): Promise<GetClaimableResponse> {
-    const method = 'get_claimable'
-    return await this.get(network, method, address)
   }
 
   async getUnclaimed(

--- a/src/api/neoLegacy/rest.ts
+++ b/src/api/neoLegacy/rest.ts
@@ -50,7 +50,7 @@ export class NeoLegacyRESTApi {
     }
 
     this.axios = axios.create(axiosConfig)
-    this.axiosDoraV2 = axios.create({ baseURL: `${DORA_URL}/api/v2/` })
+    this.axiosDoraV2 = axios.create({ baseURL: `${DORA_URL}/api/v2` })
   }
 
   async addressStats(

--- a/src/api/neoN3/rest.ts
+++ b/src/api/neoN3/rest.ts
@@ -9,7 +9,6 @@ import type {
   ContractResponse,
   ContractsResponse,
   ContractStatsResponse,
-  GetAllNodesResponse,
   HeightResponse,
   InvocationStatsResponse,
   LogResponse,
@@ -160,11 +159,6 @@ export class NeoRESTApi {
   ): Promise<ContractStatsResponse> {
     const method = 'contract_stats'
     return await this.get(network, method, contractHash)
-  }
-
-  async getAllNodes(network = 'mainnet'): Promise<GetAllNodesResponse> {
-    const method = 'get_all_nodes'
-    return await this.get(network, method)
   }
 
   async height(network = 'mainnet'): Promise<HeightResponse> {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,1 @@
-export const DORA_URL = 'https://dora.coz.io'
+export const DORA_URL = 'https://api.coz.io'

--- a/src/interfaces/api/neo/responses.ts
+++ b/src/interfaces/api/neo/responses.ts
@@ -3,7 +3,6 @@ import {
   ContractInvocationStats,
   Balance,
   Block,
-  NodeMetaData,
   TransferAbstract,
   TypedResponse,
   Witness
@@ -87,8 +86,6 @@ export interface ContractsResponse {
   totalCount: number
 }
 
-export type GetAllNodesResponse = NodeMetaData[]
-
 export interface HeightResponse {
   height: number
 }
@@ -107,7 +104,6 @@ export interface LogResponse {
 }
 
 export type TokenProvenanceResponse = Provenance[]
-
 
 export type TransactionResponse = Transaction
 

--- a/src/interfaces/api/neo_legacy/responses.ts
+++ b/src/interfaces/api/neo_legacy/responses.ts
@@ -1,7 +1,6 @@
 import {
   ApplicationLog,
   Asset,
-  ClaimableEvent,
   ContractMetaData,
   ContractState,
   ContractStorage,
@@ -82,12 +81,6 @@ export interface GetAddressAbstractsResponse {
 }
 
 export type GetAllNodesResponse = NodeMetaData[]
-
-export interface GetClaimableResponse {
-  claimable: ClaimableEvent[]
-  address: string
-  unclaimed: number
-}
 
 export interface GetUnclaimedResponse {
   available: number

--- a/src/tests/api/Ethereum/ethereum.test.ts
+++ b/src/tests/api/Ethereum/ethereum.test.ts
@@ -3,12 +3,12 @@ import { EthereumREST } from '../../../api'
 
 describe('Ethereum SDK', () => {
   it('Should get full transactions by address (Ethereum Mainnet)', async () => {
-    const address = '0xe688b84b23f322a994A53dbF8E15FA82CDB71127'
+    const address = '0xc1E563e0bA11485861198e32e25C216B312B219a'
     const response = await EthereumREST.getFullTransactionsByAddress({
       address,
       network: '1',
-      timestampFrom: '2025-01-27T12:00:00Z',
-      timestampTo: '2025-01-27T13:47:00Z'
+      timestampFrom: '2025-10-23T08:45:00Z',
+      timestampTo: '2025-10-23T08:47:59Z'
     })
 
     assert.strictEqual(response.address, address)
@@ -49,12 +49,12 @@ describe('Ethereum SDK', () => {
   })
 
   it('Should get full transactions by address (Base Mainnet)', async () => {
-    const address = '0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24'
+    const address = '0xD88Df42a769e452897EC3312389E29B592e1726B'
     const response = await EthereumREST.getFullTransactionsByAddress({
       address,
       network: '8453',
-      timestampFrom: '2025-01-30T07:59:53Z',
-      timestampTo: '2025-04-24T19:44:09Z'
+      timestampFrom: '2025-10-22T07:59:53Z',
+      timestampTo: '2025-10-22T19:44:09Z'
     })
 
     assert.strictEqual(response.address, address)
@@ -95,12 +95,12 @@ describe('Ethereum SDK', () => {
   })
 
   it('Should get full transactions by address (Arbitrum Mainnet)', async () => {
-    const address = '0x881E7C4C90f2D7f013558CAf4feca330C327E476'
+    const address = '0xE5Ab7242F453172b978A4DC5aEdc7096B8196cb6'
     const response = await EthereumREST.getFullTransactionsByAddress({
       address,
       network: '42161',
-      timestampFrom: '2025-01-30T08:06:33Z',
-      timestampTo: '2025-01-30T08:06:34Z'
+      timestampFrom: '2025-10-23T09:40:33Z',
+      timestampTo: '2025-10-23T09:48:34Z'
     })
 
     assert.strictEqual(response.address, address)
@@ -141,12 +141,12 @@ describe('Ethereum SDK', () => {
   })
 
   it('Should get full transactions by address (Polygon Mainnet)', async () => {
-    const address = '0x8dcAc06A65bBE5B9b43368B6301598195A2C8c5a'
+    const address = '0x0D0Ee387a47827862D7059204f23f67E59cc509B'
     const response = await EthereumREST.getFullTransactionsByAddress({
       address,
       network: '137',
-      timestampFrom: '2025-01-30T13:34:42Z',
-      timestampTo: '2025-04-24T20:12:03Z'
+      timestampFrom: '2025-08-22T00:00:00Z',
+      timestampTo: '2025-08-22T23:59:59Z'
     })
 
     assert.strictEqual(response.address, address)
@@ -187,82 +187,74 @@ describe('Ethereum SDK', () => {
   })
 
   it('Should get full transactions by address (Ethereum Mainnet) with default pageLimit', async () => {
-    const address = '0xe688b84b23f322a994A53dbF8E15FA82CDB71127'
+    const address = '0xbE36FfB83dB26E71Ac90b3ffB0D7D9d99F021a0D'
     const response = await EthereumREST.getFullTransactionsByAddress({
       address,
       network: '1',
-      timestampFrom: '2024-08-27T12:00:00Z',
-      timestampTo: '2025-01-27T13:47:00Z'
+      timestampFrom: '2025-10-13T08:45:00Z',
+      timestampTo: '2025-10-23T08:47:59Z'
     })
 
     assert.strictEqual(response.data.length, 50)
   })
 
   it('Should export full transactions by address (Ethereum Mainnet)', async () => {
-    const address = '0xe688b84b23f322a994A53dbF8E15FA82CDB71127'
+    const address = '0xc1E563e0bA11485861198e32e25C216B312B219a'
     const response = await EthereumREST.exportFullTransactionsByAddress({
       address,
       network: '1',
-      timestampFrom: '2025-01-27T12:00:00Z',
-      timestampTo: '2025-01-27T13:47:00Z'
+      timestampFrom: '2025-10-23T08:45:00Z',
+      timestampTo: '2025-10-23T08:47:59Z'
     })
 
-    assert.isNotEmpty(
-      response.replace(
-        'Date;Block;Transaction ID;Network fee;System fee;Contract name;Contract hash;From;To;Amount;Token ID;Standards',
-        ''
-      )
-    )
+    const needle =
+      'Date;Block;Transaction ID;Transaction Sender;Network fee;System fee;Contract name;Contract hash;From;To;Amount;Token ID;Standards'
+    assert.include(response, needle, 'header not found')
+    assert.isNotEmpty(response.replace(needle, ''))
   })
 
   it('Should export full transactions by address (Base Mainnet)', async () => {
-    const address = '0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24'
+    const address = '0xD88Df42a769e452897EC3312389E29B592e1726B'
     const response = await EthereumREST.exportFullTransactionsByAddress({
       address,
       network: '8453',
-      timestampFrom: '2025-01-30T07:59:53Z',
-      timestampTo: '2025-04-24T19:44:09Z'
+      timestampFrom: '2025-10-22T07:59:53Z',
+      timestampTo: '2025-10-22T19:44:09Z'
     })
 
-    assert.isNotEmpty(
-      response.replace(
-        'Date;Block;Transaction ID;Network fee;System fee;Contract name;Contract hash;From;To;Amount;Token ID;Standards',
-        ''
-      )
-    )
+    const needle =
+      'Date;Block;Transaction ID;Transaction Sender;Network fee;System fee;Contract name;Contract hash;From;To;Amount;Token ID;Standards'
+    assert.include(response, needle, 'header not found')
+    assert.isNotEmpty(response.replace(needle, ''))
   })
 
   it('Should export full transactions by address (Arbitrum Mainnet)', async () => {
-    const address = '0x881E7C4C90f2D7f013558CAf4feca330C327E476'
+    const address = '0xE5Ab7242F453172b978A4DC5aEdc7096B8196cb6'
     const response = await EthereumREST.exportFullTransactionsByAddress({
       address,
       network: '42161',
-      timestampFrom: '2025-01-30T08:06:33Z',
-      timestampTo: '2025-01-30T08:06:34Z'
+      timestampFrom: '2025-10-23T09:40:33Z',
+      timestampTo: '2025-10-23T09:48:34Z'
     })
 
-    assert.isNotEmpty(
-      response.replace(
-        'Date;Block;Transaction ID;Network fee;System fee;Contract name;Contract hash;From;To;Amount;Token ID;Standards',
-        ''
-      )
-    )
+    const needle =
+      'Date;Block;Transaction ID;Transaction Sender;Network fee;System fee;Contract name;Contract hash;From;To;Amount;Token ID;Standards'
+    assert.include(response, needle, 'header not found')
+    assert.isNotEmpty(response.replace(needle, ''))
   })
 
   it('Should export full transactions by address (Polygon Mainnet)', async () => {
-    const address = '0x8dcAc06A65bBE5B9b43368B6301598195A2C8c5a'
+    const address = '0x0D0Ee387a47827862D7059204f23f67E59cc509B'
     const response = await EthereumREST.exportFullTransactionsByAddress({
       address,
       network: '137',
-      timestampFrom: '2025-01-30T13:34:42Z',
-      timestampTo: '2025-04-24T20:12:03Z'
+      timestampFrom: '2025-08-22T00:00:00Z',
+      timestampTo: '2025-08-22T23:59:59Z'
     })
 
-    assert.isNotEmpty(
-      response.replace(
-        'Date;Block;Transaction ID;Network fee;System fee;Contract name;Contract hash;From;To;Amount;Token ID;Standards',
-        ''
-      )
-    )
+    const needle =
+      'Date;Block;Transaction ID;Transaction Sender;Network fee;System fee;Contract name;Contract hash;From;To;Amount;Token ID;Standards'
+    assert.include(response, needle, 'header not found')
+    assert.isNotEmpty(response.replace(needle, ''))
   })
 })

--- a/src/tests/api/NeoLegacy/neo_legacy.test.ts
+++ b/src/tests/api/NeoLegacy/neo_legacy.test.ts
@@ -20,14 +20,6 @@ describe('neo legacy', () => {
   //   assert.strictEqual(res.entries.length, 15)
   // })
 
-  it('should get the claimable transactions', async () => {
-    const res = await NeoLegacyREST.getClaimable(
-      'AciSRoWhAF95rvJVkWX38XfNPLLDjWEsoE'
-    )
-    assert.isNotNull(res)
-    assert.isNumber(Object.keys(res).length)
-  })
-
   it('should get the unclaimed metadata', async () => {
     const res = await NeoLegacyREST.getUnclaimed(
       'AciSRoWhAF95rvJVkWX38XfNPLLDjWEsoE'

--- a/src/tests/api/NeoN3/neo.test.ts
+++ b/src/tests/api/NeoN3/neo.test.ts
@@ -90,11 +90,6 @@ describe('neo sdk', () => {
     assert.isObject(res)
   })
 
-  it('should get nodes', async () => {
-    const res = await NeoN3REST.getAllNodes('testnet')
-    assert.isNotNull(res)
-  })
-
   it('should get the block height', async () => {
     const res = await NeoN3REST.height('testnet')
     assert.isNotNull(res)


### PR DESCRIPTION
- update base URL to `api.coz.io` (same as https://github.com/CityOfZion/blockchain-services/pull/221)
- fix all failing tests
   - `getClaimable` is removed because that no longer exists on the stripped down neolegacy API
   - `getAllNodes` is removed because that no longer exists on the N3 API
   - Most activity history tests needed updating as they were using very large addresses that are now blacklisted by the back-end
- the activity history CSV tests were changed because a change in CSV header on the back-end would cause it to not be stripped and as a result always pass