### PR TITLE
API consistency: standardize activity history types without renaming methods

### DIFF
--- a/src/api/ethereum/rest.ts
+++ b/src/api/ethereum/rest.ts
@@ -2,11 +2,11 @@ import { COZ_API_URL } from '../../constants'
 import type { AxiosInstance, AxiosResponse } from 'axios'
 import axios from 'axios'
 import {
-  AxiosGetFullTransactionsByAddressParams,
-  ExportFullTransactionsByAddressParams,
-  GetFullTransactionsByAddressParams
+  AxiosActivityHistoryParams,
+  ExportActivityHistoryParams,
+  ActivityHistoryParams
 } from '../../interfaces/api/ethereum'
-import { GetFullTransactionsByAddressResponse } from '../../interfaces/api/common'
+import { ActivityHistoryResponse } from '../../interfaces/api/common'
 
 export class EthereumRESTApi {
   private axiosApiV2: AxiosInstance
@@ -16,12 +16,12 @@ export class EthereumRESTApi {
   }
 
   async getFullTransactionsByAddress(
-    params: GetFullTransactionsByAddressParams
-  ): Promise<GetFullTransactionsByAddressResponse> {
+    params: ActivityHistoryParams
+  ): Promise<ActivityHistoryResponse> {
     const { data } = await this.axiosApiV2.post<
-      GetFullTransactionsByAddressResponse,
-      AxiosResponse<GetFullTransactionsByAddressResponse>,
-      AxiosGetFullTransactionsByAddressParams
+      ActivityHistoryResponse,
+      AxiosResponse<ActivityHistoryResponse>,
+      AxiosActivityHistoryParams
     >('/unified/activity-history', {
       pageLimit: 50,
       ...params,
@@ -32,7 +32,7 @@ export class EthereumRESTApi {
   }
 
   async exportFullTransactionsByAddress(
-    params: ExportFullTransactionsByAddressParams
+    params: ExportActivityHistoryParams
   ): Promise<string> {
     const { data } = await this.axiosApiV2.post<string>(
       '/unified/activity-history-csv',

--- a/src/api/neoLegacy/rest.ts
+++ b/src/api/neoLegacy/rest.ts
@@ -3,22 +3,22 @@ import axios from 'axios'
 
 import { COZ_API_URL } from '../../constants'
 import type { RestConfig } from '../../interfaces'
-import type { GetFullTransactionsByAddressResponse } from '../../interfaces/api/common'
+import type { ActivityHistoryResponse } from '../../interfaces/api/common'
 import type {
   AddressStatsResponse,
   AssetResponse,
   AssetsResponse,
-  AxiosGetFullTransactionsByAddressParams,
+  AxiosActivityHistoryParams,
   BalanceResponse,
   BlockResponse,
   BlocksResponse,
   ContractResponse,
   ContractsResponse,
   ContractTransfersResponse,
-  ExportFullTransactionsByAddressParams,
+  ExportActivityHistoryParams,
   GetAddressAbstractsResponse,
   GetAllNodesResponse,
-  GetFullTransactionsByAddressParams,
+  ActivityHistoryParams,
   GetUnclaimedResponse,
   HeightResponse,
   InvocationStatsResponse,
@@ -203,12 +203,12 @@ export class NeoLegacyRESTApi {
   }
 
   async getFullTransactionsByAddress(
-    params: GetFullTransactionsByAddressParams
-  ): Promise<GetFullTransactionsByAddressResponse> {
+    params: ActivityHistoryParams
+  ): Promise<ActivityHistoryResponse> {
     const { data } = await this.axiosApiV2.post<
-      GetFullTransactionsByAddressResponse,
-      AxiosResponse<GetFullTransactionsByAddressResponse>,
-      AxiosGetFullTransactionsByAddressParams
+      ActivityHistoryResponse,
+      AxiosResponse<ActivityHistoryResponse>,
+      AxiosActivityHistoryParams
     >('/unified/activity-history', {
       pageLimit: 30,
       ...params,
@@ -219,7 +219,7 @@ export class NeoLegacyRESTApi {
   }
 
   async exportFullTransactionsByAddress(
-    params: ExportFullTransactionsByAddressParams
+    params: ExportActivityHistoryParams
   ): Promise<string> {
     const { data } = await this.axiosApiV2.post<string>(
       '/unified/activity-history-csv',

--- a/src/api/neoN3/rest.ts
+++ b/src/api/neoN3/rest.ts
@@ -17,14 +17,14 @@ import type {
   TransactionsResponse,
   TransferHistoryResponse,
   VoterResponse,
-  AxiosGetFullTransactionsByAddressParams,
-  GetFullTransactionsByAddressParams,
-  ExportFullTransactionsByAddressParams
+  AxiosActivityHistoryParams,
+  ActivityHistoryParams,
+  ExportActivityHistoryParams
 } from '../../interfaces/api/neo'
 import { COZ_API_URL } from '../../constants'
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 import axios from 'axios'
-import { GetFullTransactionsByAddressResponse } from '../../interfaces/api/common'
+import { ActivityHistoryResponse } from '../../interfaces/api/common'
 import { RestConfig } from '../../interfaces'
 
 const defaultRestConfig: RestConfig = {
@@ -218,12 +218,12 @@ export class NeoRESTApi {
   }
 
   async getFullTransactionsByAddress(
-    params: GetFullTransactionsByAddressParams
-  ): Promise<GetFullTransactionsByAddressResponse> {
+    params: ActivityHistoryParams
+  ): Promise<ActivityHistoryResponse> {
     const { data } = await this.axiosApiV2.post<
-      GetFullTransactionsByAddressResponse,
-      AxiosResponse<GetFullTransactionsByAddressResponse>,
-      AxiosGetFullTransactionsByAddressParams
+      ActivityHistoryResponse,
+      AxiosResponse<ActivityHistoryResponse>,
+      AxiosActivityHistoryParams
     >('/unified/activity-history', {
       pageLimit: 50,
       ...params,
@@ -234,7 +234,7 @@ export class NeoRESTApi {
   }
 
   async exportFullTransactionsByAddress(
-    params: ExportFullTransactionsByAddressParams
+    params: ExportActivityHistoryParams
   ): Promise<string> {
     const { data } = await this.axiosApiV2.post<string>(
       '/unified/activity-history-csv',

--- a/src/api/neox/rest.ts
+++ b/src/api/neox/rest.ts
@@ -7,11 +7,11 @@ import type {
   Blocks,
   Stats,
   Transaction,
-  AxiosGetFullTransactionsByAddressParams,
-  GetFullTransactionsByAddressParams,
-  ExportFullTransactionsByAddressParams
+  AxiosActivityHistoryParams,
+  ActivityHistoryParams,
+  ExportActivityHistoryParams
 } from '../../interfaces/api/neox'
-import { GetFullTransactionsByAddressResponse } from '../../interfaces/api/common'
+import { ActivityHistoryResponse } from '../../interfaces/api/common'
 import { RestConfig } from '../../interfaces'
 
 const defaultRestConfig: RestConfig = {
@@ -71,12 +71,12 @@ export class NeoXRESTApi {
   }
 
   async getFullTransactionsByAddress(
-    params: GetFullTransactionsByAddressParams
-  ): Promise<GetFullTransactionsByAddressResponse> {
+    params: ActivityHistoryParams
+  ): Promise<ActivityHistoryResponse> {
     const { data } = await this.axiosApiV2.post<
-      GetFullTransactionsByAddressResponse,
-      AxiosResponse<GetFullTransactionsByAddressResponse>,
-      AxiosGetFullTransactionsByAddressParams
+      ActivityHistoryResponse,
+      AxiosResponse<ActivityHistoryResponse>,
+      AxiosActivityHistoryParams
     >('/unified/activity-history', {
       pageLimit: 50,
       ...params,
@@ -87,7 +87,7 @@ export class NeoXRESTApi {
   }
 
   async exportFullTransactionsByAddress(
-    params: ExportFullTransactionsByAddressParams
+    params: ExportActivityHistoryParams
   ): Promise<string> {
     const { data } = await this.axiosApiV2.post<string>(
       '/unified/activity-history-csv',

--- a/src/interfaces/api/common/index.ts
+++ b/src/interfaces/api/common/index.ts
@@ -86,7 +86,7 @@ export type CommonExportFullTransactionsByAddressParams = {
   timestampTo: string
 }
 
-type FullTransactionsEvent = {
+export type ActivityHistoryEvent = {
   amount: string
   from: string | null
   to: string | null
@@ -99,7 +99,7 @@ type FullTransactionsEvent = {
   tokenType: string
 }
 
-type FullTransactionsItem = {
+export type ActivityHistoryItem = {
   transactionID: string
   block: number
   date: string
@@ -107,13 +107,15 @@ type FullTransactionsItem = {
   notificationCount: number
   networkFeeAmount: string
   systemFeeAmount: string
-  events: FullTransactionsEvent[]
+  events: ActivityHistoryEvent[]
 }
 
-export type GetFullTransactionsByAddressResponse = {
+export type ActivityHistoryResponse = {
   address: string
   protocol: string
   network: string
   nextCursor: string
-  data: FullTransactionsItem[]
+  data: ActivityHistoryItem[]
 }
+
+export type GetFullTransactionsByAddressResponse = ActivityHistoryResponse

--- a/src/interfaces/api/ethereum/index.ts
+++ b/src/interfaces/api/ethereum/index.ts
@@ -10,14 +10,20 @@ export type NetworkType =
   | '137'
   | (string & NonNullable<unknown>)
 
-export type GetFullTransactionsByAddressParams = {
+export type ActivityHistoryParams = {
   network: NetworkType
 } & CommonGetFullTransactionsByAddressParams
 
-export type AxiosGetFullTransactionsByAddressParams = {
-  protocol: 'ethereum'
-} & GetFullTransactionsByAddressParams
+export type GetFullTransactionsByAddressParams = ActivityHistoryParams
 
-export type ExportFullTransactionsByAddressParams = {
+export type AxiosActivityHistoryParams = {
+  protocol: 'ethereum'
+} & ActivityHistoryParams
+
+export type AxiosGetFullTransactionsByAddressParams = AxiosActivityHistoryParams
+
+export type ExportActivityHistoryParams = {
   network: NetworkType
 } & CommonExportFullTransactionsByAddressParams
+
+export type ExportFullTransactionsByAddressParams = ExportActivityHistoryParams

--- a/src/interfaces/api/neo/interface.ts
+++ b/src/interfaces/api/neo/interface.ts
@@ -206,14 +206,20 @@ export interface Transfer {
 
 export type NetworkType = 'mainnet' | 'testnet'
 
-export type GetFullTransactionsByAddressParams = {
+export type ActivityHistoryParams = {
   network: NetworkType
 } & CommonGetFullTransactionsByAddressParams
 
-export type ExportFullTransactionsByAddressParams = {
+export type GetFullTransactionsByAddressParams = ActivityHistoryParams
+
+export type ExportActivityHistoryParams = {
   network: NetworkType
 } & CommonExportFullTransactionsByAddressParams
 
-export type AxiosGetFullTransactionsByAddressParams = {
+export type ExportFullTransactionsByAddressParams = ExportActivityHistoryParams
+
+export type AxiosActivityHistoryParams = {
   protocol: 'neo3'
-} & GetFullTransactionsByAddressParams
+} & ActivityHistoryParams
+
+export type AxiosGetFullTransactionsByAddressParams = AxiosActivityHistoryParams

--- a/src/interfaces/api/neo_legacy/interface.ts
+++ b/src/interfaces/api/neo_legacy/interface.ts
@@ -117,14 +117,20 @@ export interface Transaction {
 
 export type NetworkType = 'mainnet'
 
-export type GetFullTransactionsByAddressParams = {
+export type ActivityHistoryParams = {
   network: NetworkType
 } & CommonGetFullTransactionsByAddressParams
 
-export type ExportFullTransactionsByAddressParams = {
+export type GetFullTransactionsByAddressParams = ActivityHistoryParams
+
+export type ExportActivityHistoryParams = {
   network: NetworkType
 } & CommonExportFullTransactionsByAddressParams
 
-export type AxiosGetFullTransactionsByAddressParams = {
+export type ExportFullTransactionsByAddressParams = ExportActivityHistoryParams
+
+export type AxiosActivityHistoryParams = {
   protocol: 'neolegacy'
-} & GetFullTransactionsByAddressParams
+} & ActivityHistoryParams
+
+export type AxiosGetFullTransactionsByAddressParams = AxiosActivityHistoryParams

--- a/src/interfaces/api/neox/index.ts
+++ b/src/interfaces/api/neox/index.ts
@@ -212,14 +212,20 @@ export interface Stats {
 
 export type NetworkType = 'mainnet' | 'testnet'
 
-export type GetFullTransactionsByAddressParams = {
+export type ActivityHistoryParams = {
   network: NetworkType
 } & CommonGetFullTransactionsByAddressParams
 
-export type ExportFullTransactionsByAddressParams = {
+export type GetFullTransactionsByAddressParams = ActivityHistoryParams
+
+export type ExportActivityHistoryParams = {
   network: NetworkType
 } & CommonExportFullTransactionsByAddressParams
 
-export type AxiosGetFullTransactionsByAddressParams = {
+export type ExportFullTransactionsByAddressParams = ExportActivityHistoryParams
+
+export type AxiosActivityHistoryParams = {
   protocol: 'neox'
-} & GetFullTransactionsByAddressParams
+} & ActivityHistoryParams
+
+export type AxiosGetFullTransactionsByAddressParams = AxiosActivityHistoryParams


### PR DESCRIPTION
## Summary
- standardize the shared unified activity history response model under consistent ActivityHistory type names
- add compatibility aliases for the existing GetFullTransactionsByAddress and export parameter type names
- keep all existing public method names unchanged

## Commits
- Standardize unified activity history response types
- Add consistent activity history type aliases

## Verification
- npm run build
- npm test

## Notes
- no public method renames
- existing exported type names remain available as aliases for compatibility